### PR TITLE
use Array.Empty<T>() where possible

### DIFF
--- a/src/BlobHelper/Blobs.cs
+++ b/src/BlobHelper/Blobs.cs
@@ -691,7 +691,7 @@ namespace BlobHelper
             string filename = DiskGenerateUrl(key);
             if (Directory.Exists(filename))
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
             else if (File.Exists(filename))
             {
@@ -824,7 +824,7 @@ namespace BlobHelper
             else
             {
                 ret.ContentLength = 0;
-                ret.Data = new MemoryStream(new byte[0]);
+                ret.Data = new MemoryStream(Array.Empty<byte>());
             }
 
             return ret; 
@@ -934,7 +934,7 @@ namespace BlobHelper
         private async Task KvpbaseWrite(string key, string contentType, byte[] data, CancellationToken token)
         {
             long contentLength = 0;
-            MemoryStream stream = new MemoryStream(new byte[0]);
+            MemoryStream stream = new MemoryStream(Array.Empty<byte>());
 
             if (data != null && data.Length > 0)
             {
@@ -954,7 +954,7 @@ namespace BlobHelper
         private async Task DiskWrite(string key, byte[] data, CancellationToken token)
         {
             long contentLength = 0;
-            MemoryStream stream = new MemoryStream(new byte[0]);
+            MemoryStream stream = new MemoryStream(Array.Empty<byte>());
 
             if (data != null && data.Length > 0)
             {
@@ -1008,7 +1008,7 @@ namespace BlobHelper
         private async Task S3Write(string key, string contentType, byte[] data, CancellationToken token)
         {
             long contentLength = 0;
-            MemoryStream stream = new MemoryStream(new byte[0]);
+            MemoryStream stream = new MemoryStream(Array.Empty<byte>());
 
             if (data != null && data.Length > 0)
             {
@@ -1030,7 +1030,7 @@ namespace BlobHelper
                 request.Key = key;
                 request.ContentType = contentType;
                 request.UseChunkEncoding = false;
-                request.InputStream = new MemoryStream(new byte[0]);
+                request.InputStream = new MemoryStream(Array.Empty<byte>());
             }
             else
             {

--- a/src/BlobHelper/WriteRequest.cs
+++ b/src/BlobHelper/WriteRequest.cs
@@ -76,7 +76,7 @@ namespace BlobHelper
         {
             if (String.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
             if (String.IsNullOrEmpty(contentType)) contentType = "application/octet-stream";
-            if (data == null) data = new byte[0];
+            if (data == null) data = Array.Empty<byte>();
 
             Key = key;
             ContentType = contentType;

--- a/src/Test/Program.cs
+++ b/src/Test/Program.cs
@@ -208,7 +208,7 @@ namespace Test
                 string contentType = Inputty.GetString("Content type :", "text/plain", true);
                 string data =        Inputty.GetString("Data         :", null, true);
 
-                byte[] bytes = new byte[0];
+                byte[] bytes = Array.Empty<byte>();
                 if (!String.IsNullOrEmpty(data)) bytes = Encoding.UTF8.GetBytes(data);
                 _Blobs.Write(key, contentType, bytes).Wait();
 


### PR DESCRIPTION
Useful in number of places that return an empty byte array to avoid unnecessary memory allocation.