### PR TITLE
use Array.Empty<byte>() and OpenRead async version

### DIFF
--- a/src/BlobHelper/Clients/AwsS3BlobClient.cs
+++ b/src/BlobHelper/Clients/AwsS3BlobClient.cs
@@ -120,7 +120,7 @@ namespace BlobHelper
             else
             {
                 ret.ContentLength = 0;
-                ret.Data = new MemoryStream(new byte[0]);
+                ret.Data = new MemoryStream(Array.Empty<byte>());
             }
 
             return ret;
@@ -168,7 +168,7 @@ namespace BlobHelper
         public async Task WriteAsync(string key, string contentType, byte[] data, CancellationToken token = default)
         {
             long contentLength = 0;
-            MemoryStream stream = new MemoryStream(new byte[0]);
+            MemoryStream stream = new MemoryStream(Array.Empty<byte>());
 
             if (data != null && data.Length > 0)
             {
@@ -191,7 +191,7 @@ namespace BlobHelper
                 request.Key = key;
                 request.ContentType = contentType;
                 request.UseChunkEncoding = false;
-                request.InputStream = new MemoryStream(new byte[0]);
+                request.InputStream = new MemoryStream(Array.Empty<byte>());
             }
             else
             {

--- a/src/BlobHelper/Clients/AzureBlobClient.cs
+++ b/src/BlobHelper/Clients/AzureBlobClient.cs
@@ -82,7 +82,7 @@ namespace BlobHelper
             byte[] buff = new byte[4096];
 
             BlobMetadata md = await GetMetadataAsync(key, token).ConfigureAwait(false);
-            BlobData bd = new BlobData(md.ContentLength, bc.OpenRead(new BlobOpenReadOptions(false)));
+            BlobData bd = new BlobData(md.ContentLength, await bc.OpenReadAsync(new BlobOpenReadOptions(false), token).ConfigureAwait(false));
             return bd;
         }
 

--- a/src/BlobHelper/Clients/DiskBlobClient.cs
+++ b/src/BlobHelper/Clients/DiskBlobClient.cs
@@ -44,7 +44,7 @@ namespace BlobHelper
             string filename = GenerateUrl(key);
             if (Directory.Exists(filename))
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
             else if (File.Exists(filename))
             {
@@ -120,7 +120,7 @@ namespace BlobHelper
         public async Task WriteAsync(string key, string contentType, byte[] data, CancellationToken token = default)
         {
             long contentLength = 0;
-            MemoryStream stream = new MemoryStream(new byte[0]);
+            MemoryStream stream = new MemoryStream(Array.Empty<byte>());
 
             if (data != null && data.Length > 0)
             {

--- a/src/BlobHelper/Clients/KvpbaseBlobClient.cs
+++ b/src/BlobHelper/Clients/KvpbaseBlobClient.cs
@@ -85,7 +85,7 @@ namespace BlobHelper
         public async Task WriteAsync(string key, string contentType, byte[] data, CancellationToken token = default)
         {
             long contentLength = 0;
-            MemoryStream stream = new MemoryStream(new byte[0]);
+            MemoryStream stream = new MemoryStream(Array.Empty<byte>());
 
             if (data != null && data.Length > 0)
             {


### PR DESCRIPTION
Hi,

if you copied code from this branch: https://github.com/revazashvili/BlobHelper/tree/refactor, it was created before you merged my PR, i thought it would be merged in PR. now `OpenRead` and `new byte[0]` are still used.

P.S there are more to fix, method calls with passing cancelation token, unused variables,redundant initializers and etc, i will send PR as soon as i can