### PR TITLE
fix isfolder always false bug

### DIFF
--- a/src/Blobject.Disk/DiskBlobClient.cs
+++ b/src/Blobject.Disk/DiskBlobClient.cs
@@ -145,10 +145,12 @@
                 DirectoryInfo di = new DirectoryInfo(filename);
                 BlobMetadata md = new BlobMetadata();
                 md.Key = key;
+                md.IsFolder = true;
                 md.ContentLength = 0;
                 md.CreatedUtc = di.CreationTimeUtc;
                 md.LastAccessUtc = di.LastAccessTimeUtc;
                 md.LastUpdateUtc = di.LastWriteTimeUtc;
+                
                 return md;
             }
             else


### PR DESCRIPTION
When Directory.Exists(filename) we were never setting IsFolder to true therefore it was set as the default which is false.